### PR TITLE
Rename Markdown helpers with an md_ prefix

### DIFF
--- a/.agents/skills/draftjs-exporter/SKILL.md
+++ b/.agents/skills/draftjs-exporter/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 Python library converting Draft.js raw [ContentState](https://wagtail.github.io/draftjs_exporter/content-state/) JSON into HTML or Markdown. Maintained by [Wagtail](https://wagtail.org/) contributors, developed alongside the [Draftail](https://www.draftail.org/) rich text editor.
 
-The public API is small: an `HTML` exporter class, a `DOM` namespace with a React-like `create_element`, default config maps (`BLOCK_MAP`, `STYLE_MAP`), constants (`BLOCK_TYPES`, `ENTITY_TYPES`, `INLINE_STYLES`), and type aliases (`Props`, `Element`, `Component`, `ContentState`). Almost everything else is configuration.
+The public API is small: an `HTMLExporter` class, a `DOM` namespace with a React-like `create_element`, default config maps (`BLOCK_MAP`, `STYLE_MAP`) and helpers (`code_block`, `render_children`), Markdown helpers (`md_*`), constants (`BLOCK_TYPES`, `ENTITY_TYPES`, `INLINE_STYLES`), and type aliases (`Props`, `Element`, `Component`, `ContentState`). Almost everything else is configuration.
 
 ## Quick reference
 
@@ -223,11 +223,13 @@ See [Markdown importer](https://wagtail.github.io/draftjs_exporter/markdown-impo
 
 All imported from `draftjs_exporter` directly:
 
-- **`HTML`** (alias: `Exporter`) — `HTML(config).render(content_state)`.
+- **`HTMLExporter`** — `HTMLExporter(config).render(content_state)`.
 - **`DOM`** — facade over the active engine. `create_element`, `render`, `render_debug`, `parse_html`, `append_child`, `camel_to_dash`. Engine constants: `DOM.STRING`, `DOM.HTML5LIB`, `DOM.LXML`, `DOM.STRING_COMPAT`, `DOM.MARKDOWN`.
 - **Default maps & configs**: `BLOCK_MAP`, `STYLE_MAP`, `HTML_CONFIG`, `MARKDOWN_CONFIG`.
+- **Default components**: `code_block` (`pre` > `code`), `render_children` (passthrough; used for atomic blocks).
 - **Constants**: `BLOCK_TYPES`, `INLINE_STYLES`, `ENTITY_TYPES` (each with a `FALLBACK` member).
 - **Markdown helper**: `build_markdown_config(options)`, plus the option type alias `MarkdownOptions`.
+- **Markdown components**: `md_block`, `md_inline`, `md_mark_safe`, `md_link_destination`, `md_link`, `md_image`, `md_prefixed_block`, `md_make_ul` / `md_ul`, `md_make_ol` / `md_ol`, `md_list_wrapper`, `md_code_element` / `md_code_wrapper`, `md_inline_style`, `md_code_span`, `md_horizontal_rule` / `md_make_horizontal_rule`, `md_*_fallback`.
 - **Importer**: `MarkdownImporter(config).import_markdown(markdown)` — converts Markdown to ContentState. Config keys: `parser` (dotted path), `parser_config` (feature toggles, `link_resolvers`/`image_resolvers`, `inline_html_styles`), `filter_rules`.
 - **Parser**: `MarkdownParser(config).parse(markdown)`, `ParserConfig`, `scheme_resolver(scheme, type_map, coerce, label_key, mutability)`, `EntityResolver`, `EntityResolution`.
 - **Filter**: `ContentStateFilter(rules).apply(content_state)`, `FilterRule` (`type`/`match`/`action`; actions `remove`/`keep`/`demote`/callable).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## [Unreleased]
 
+## [v7.1.0](https://github.com/wagtail/draftjs_exporter/releases/tag/v7.1.0)
+
+### Added
+
+- Re-export `code_block` and `render_children` from the package root.
+- Add `HTMLExporter` as a compatibility alias for `HTML` (alongside `Exporter`).
+- Re-export Markdown helpers from the package root with an `md_` prefix (for example `md_link`, `md_image`, `md_mark_safe`, `md_prefixed_block`).
+
+### Changed
+
+- Rename Markdown component helpers to use an `md_` prefix (for example `link` → `md_link`, `mark_safe` → `md_mark_safe`). Import them from `draftjs_exporter` under their new names.
+
 ## [v7.0.0](https://github.com/wagtail/draftjs_exporter/releases/tag/v7.0.0)
 
 ### Added

--- a/docs/guides/custom-components.md
+++ b/docs/guides/custom-components.md
@@ -44,6 +44,17 @@ def blockquote(props):
 
 Pass `props['children']` as the last argument to `DOM.create_element` so the block's content is displayed inside the element you create.
 
+The package also ships two reusable block components you can import from the root:
+
+```python
+from draftjs_exporter import code_block, render_children
+```
+
+- `code_block` wraps children in `<pre><code>…</code></pre>` (used by default for `BLOCK_TYPES.CODE`).
+- `render_children` returns children with no wrapping markup (used by default for `BLOCK_TYPES.ATOMIC`).
+
+Reuse them when extending `BLOCK_MAP`, or as a starting point for your own components.
+
 ## Nesting and reusing components
 
 `DOM.create_element` accepts any number of children after the props dict. Children can be strings, DOM elements, other components, or `None` (which renders nothing). This lets you compose components the same way you would compose HTML tags.

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -51,12 +51,11 @@ All are optional. Omitted options use the defaults shown below. All defaults pro
 The three fallback options control what happens when the exporter encounters a block type, entity type, or inline style that has no explicit mapping. By default, each logs a warning and renders the content as plain text. Pass a custom `Component` function to change this behavior, or `None` to disable the fallback entirely.
 
 ```python
-from draftjs_exporter import HTML, build_markdown_config
-from draftjs_exporter.markdown.helpers import block
+from draftjs_exporter import HTML, build_markdown_config, md_block
 
 
 def my_block_fallback(props):
-    return block(["<!-- unknown --> ", props["children"]])
+    return md_block(["<!-- unknown --> ", props["children"]])
 
 
 config = build_markdown_config({
@@ -101,49 +100,62 @@ The following table shows every Draft.js content type the Markdown exporter hand
 
 ## Low-level API
 
-For cases where `build_markdown_config` is not flexible enough, you can build a config dict manually from the individual component functions. This is the same approach used by the default `CONFIG` and `build_markdown_config` internally. The constants and default maps are available from the top-level package; the Markdown-specific component functions live in submodules:
+For cases where `build_markdown_config` is not flexible enough, you can build a config dict manually from the individual component functions. This is the same approach used by the default `CONFIG` and `build_markdown_config` internally. All Markdown helpers are re-exported from the package root with an `md_` prefix:
 
 ```python
-from draftjs_exporter import BLOCK_MAP as HTML_BLOCK_MAP, BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES, STYLE_MAP as HTML_STYLE_MAP
-from draftjs_exporter.markdown.blocks import list_wrapper, make_ul, ol, prefixed_block
-from draftjs_exporter.markdown.code import code_element, code_wrapper
-from draftjs_exporter.markdown.entities import image, link, make_horizontal_rule
-from draftjs_exporter.markdown.styles import code_span, inline_style
+from draftjs_exporter import (
+    BLOCK_MAP as HTML_BLOCK_MAP,
+    BLOCK_TYPES,
+    ENTITY_TYPES,
+    INLINE_STYLES,
+    STYLE_MAP as HTML_STYLE_MAP,
+    md_code_element,
+    md_code_span,
+    md_code_wrapper,
+    md_image,
+    md_inline_style,
+    md_link,
+    md_list_wrapper,
+    md_make_horizontal_rule,
+    md_make_ul,
+    md_ol,
+    md_prefixed_block,
+)
 
 config = {
     "engine": "draftjs_exporter.engines.markdown.DOMMarkdown",
     "block_map": {
         **HTML_BLOCK_MAP,
-        BLOCK_TYPES.UNSTYLED: prefixed_block(""),
-        BLOCK_TYPES.HEADER_ONE: prefixed_block("# "),
+        BLOCK_TYPES.UNSTYLED: md_prefixed_block(""),
+        BLOCK_TYPES.HEADER_ONE: md_prefixed_block("# "),
         # ... other headings ...
         BLOCK_TYPES.UNORDERED_LIST_ITEM: {
-            "element": make_ul("*"),
-            "wrapper": list_wrapper,
+            "element": md_make_ul("*"),
+            "wrapper": md_list_wrapper,
         },
         BLOCK_TYPES.ORDERED_LIST_ITEM: {
-            "element": ol,
-            "wrapper": list_wrapper,
+            "element": md_ol,
+            "wrapper": md_list_wrapper,
         },
-        BLOCK_TYPES.BLOCKQUOTE: prefixed_block("> ", block_prefix=True),
+        BLOCK_TYPES.BLOCKQUOTE: md_prefixed_block("> ", block_prefix=True),
         BLOCK_TYPES.CODE: {
-            "element": code_element,
-            "wrapper": code_wrapper,
+            "element": md_code_element,
+            "wrapper": md_code_wrapper,
         },
     },
     "style_map": dict(
         HTML_STYLE_MAP,
         **{
-            INLINE_STYLES.BOLD: inline_style("__"),
-            INLINE_STYLES.CODE: code_span,
-            INLINE_STYLES.ITALIC: inline_style("*"),
-            INLINE_STYLES.STRIKETHROUGH: inline_style("~~"),
+            INLINE_STYLES.BOLD: md_inline_style("__"),
+            INLINE_STYLES.CODE: md_code_span,
+            INLINE_STYLES.ITALIC: md_inline_style("*"),
+            INLINE_STYLES.STRIKETHROUGH: md_inline_style("~~"),
         },
     ),
     "entity_decorators": {
-        ENTITY_TYPES.IMAGE: image,
-        ENTITY_TYPES.LINK: link,
-        ENTITY_TYPES.HORIZONTAL_RULE: make_horizontal_rule("***"),
+        ENTITY_TYPES.IMAGE: md_image,
+        ENTITY_TYPES.LINK: md_link,
+        ENTITY_TYPES.HORIZONTAL_RULE: md_make_horizontal_rule("***"),
     },
 }
 ```
@@ -179,11 +191,10 @@ exporter.render({
 
 ### Escaping in custom components
 
-When you write custom Markdown components, any plain strings they emit are escaped as user text. Wrap structural syntax with `mark_safe` so it renders verbatim, and route URLs through `link_destination`:
+When you write custom Markdown components, any plain strings they emit are escaped as user text. Wrap structural syntax with `md_mark_safe` so it renders verbatim, and route URLs through `md_link_destination`:
 
 ```python
-from draftjs_exporter import DOM, Element, Props
-from draftjs_exporter.markdown.helpers import link_destination, mark_safe
+from draftjs_exporter import DOM, Element, Props, md_link_destination, md_mark_safe
 
 
 def mention(props: Props) -> Element:
@@ -192,16 +203,16 @@ def mention(props: Props) -> Element:
         "fragment",
         {},
         [
-            mark_safe("[@"),
+            md_mark_safe("[@"),
             props["children"],  # Plain text, escaped automatically.
-            mark_safe("]("),
-            link_destination(props["url"]),  # Escaped for ](…) destinations.
-            mark_safe(")"),
+            md_mark_safe("]("),
+            md_link_destination(props["url"]),  # Escaped for ](…) destinations.
+            md_mark_safe(")"),
         ],
     )
 ```
 
-Use `mark_safe(markup, block_prefix=True)` for prefixes after which nested blocks can start (list markers, blockquote `> `), so text following them still gets line-start escaping. The escaping functions are also available directly for lower-level needs:
+Use `md_mark_safe(markup, block_prefix=True)` for prefixes after which nested blocks can start (list markers, blockquote `> `), so text following them still gets line-start escaping. The escaping functions are also available directly for lower-level needs:
 
 ```python
 from draftjs_exporter.markdown.escape import escape_link_destination, escape_text

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -2,7 +2,7 @@
 
 This page collects the upgrade notes for each major (and selected minor) release of the exporter. Each section describes the breaking changes and the steps to follow when upgrading from the previous version. For the full list of changes in each release, see the [CHANGELOG](https://github.com/wagtail/draftjs_exporter/blob/main/CHANGELOG.md).
 
-## Upgrading to v6.1.0
+## Upgrading to v7.0.0
 
 ### Markdown export now escapes text
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,10 +7,10 @@ The exporter output is extensively configurable to cater for varied rich text re
 The configuration is a single dict passed to `HTML()`. It has four keys: `block_map`, `style_map`, `entity_decorators`, and `composite_decorators`. Each is optional and can be combined with the defaults the exporter provides.
 
 ```python
-from draftjs_exporter import BLOCK_MAP, BLOCK_TYPES, DOM, ENTITY_TYPES, INLINE_STYLES, STYLE_MAP
+from draftjs_exporter import BLOCK_MAP, BLOCK_TYPES, DOM, ENTITY_TYPES, INLINE_STYLES, STYLE_MAP, code_block, render_children
 ```
 
-The exporter ships with `BLOCK_MAP` and `STYLE_MAP` — sensible defaults for common HTML elements. Extend them with `**` to start from the defaults, or build your own from scratch.
+The exporter ships with `BLOCK_MAP` and `STYLE_MAP` — sensible defaults for common HTML elements. Extend them with `**` to start from the defaults, or build your own from scratch. The default `CODE` and `ATOMIC` entries use the reusable `code_block` and `render_children` components; import those when you want the same behavior in a custom map.
 
 ## Block map
 

--- a/draftjs_exporter/__init__.py
+++ b/draftjs_exporter/__init__.py
@@ -21,6 +21,8 @@ from draftjs_exporter.contentstate_filter import (
 from draftjs_exporter.contentstate_filter import FilterRule as FilterRule
 from draftjs_exporter.defaults import BLOCK_MAP as BLOCK_MAP
 from draftjs_exporter.defaults import STYLE_MAP as STYLE_MAP
+from draftjs_exporter.defaults import code_block as code_block
+from draftjs_exporter.defaults import render_children as render_children
 from draftjs_exporter.dom import DOM as DOM
 from draftjs_exporter.error import MarkdownParseError as MarkdownParseError
 from draftjs_exporter.html import HTML as HTML
@@ -28,6 +30,31 @@ from draftjs_exporter.html import ExporterConfig as ExporterConfig
 from draftjs_exporter.markdown import CONFIG as MARKDOWN_CONFIG
 from draftjs_exporter.markdown import MarkdownOptions as MarkdownOptions
 from draftjs_exporter.markdown import build_markdown_config as build_markdown_config
+from draftjs_exporter.markdown.blocks import md_list_wrapper as md_list_wrapper
+from draftjs_exporter.markdown.blocks import md_make_ol as md_make_ol
+from draftjs_exporter.markdown.blocks import md_make_ul as md_make_ul
+from draftjs_exporter.markdown.blocks import md_ol as md_ol
+from draftjs_exporter.markdown.blocks import md_prefixed_block as md_prefixed_block
+from draftjs_exporter.markdown.blocks import md_ul as md_ul
+from draftjs_exporter.markdown.code import md_code_element as md_code_element
+from draftjs_exporter.markdown.code import md_code_wrapper as md_code_wrapper
+from draftjs_exporter.markdown.code import md_make_code_element as md_make_code_element
+from draftjs_exporter.markdown.code import md_make_code_wrapper as md_make_code_wrapper
+from draftjs_exporter.markdown.entities import md_horizontal_rule as md_horizontal_rule
+from draftjs_exporter.markdown.entities import md_image as md_image
+from draftjs_exporter.markdown.entities import md_link as md_link
+from draftjs_exporter.markdown.entities import (
+    md_make_horizontal_rule as md_make_horizontal_rule,
+)
+from draftjs_exporter.markdown.fallbacks import md_block_fallback as md_block_fallback
+from draftjs_exporter.markdown.fallbacks import md_entity_fallback as md_entity_fallback
+from draftjs_exporter.markdown.fallbacks import md_style_fallback as md_style_fallback
+from draftjs_exporter.markdown.helpers import md_block as md_block
+from draftjs_exporter.markdown.helpers import md_inline as md_inline
+from draftjs_exporter.markdown.helpers import md_link_destination as md_link_destination
+from draftjs_exporter.markdown.helpers import md_mark_safe as md_mark_safe
+from draftjs_exporter.markdown.styles import md_code_span as md_code_span
+from draftjs_exporter.markdown.styles import md_inline_style as md_inline_style
 from draftjs_exporter.markdown_importer import ImporterConfig as ImporterConfig
 from draftjs_exporter.markdown_importer import MarkdownImporter as MarkdownImporter
 from draftjs_exporter.markdown_parser import EntityResolution as EntityResolution
@@ -64,6 +91,7 @@ __all__ = [
     # Core
     "Exporter",
     "HTML",
+    "HTMLExporter",
     "ExporterConfig",
     "ContentState",
     "DOM",
@@ -72,6 +100,30 @@ __all__ = [
     "MARKDOWN_CONFIG",
     "MarkdownOptions",
     "build_markdown_config",
+    # Markdown helpers
+    "md_block",
+    "md_block_fallback",
+    "md_code_element",
+    "md_code_span",
+    "md_code_wrapper",
+    "md_entity_fallback",
+    "md_horizontal_rule",
+    "md_image",
+    "md_inline",
+    "md_inline_style",
+    "md_link",
+    "md_link_destination",
+    "md_list_wrapper",
+    "md_make_code_element",
+    "md_make_code_wrapper",
+    "md_make_horizontal_rule",
+    "md_make_ol",
+    "md_make_ul",
+    "md_mark_safe",
+    "md_ol",
+    "md_prefixed_block",
+    "md_style_fallback",
+    "md_ul",
     # Importer
     "MarkdownImporter",
     "ImporterConfig",
@@ -87,9 +139,11 @@ __all__ = [
     "BLOCK_TYPES",
     "ENTITY_TYPES",
     "INLINE_STYLES",
-    # Default maps
+    # Defaults
     "BLOCK_MAP",
     "STYLE_MAP",
+    "code_block",
+    "render_children",
     # Types
     "Block",
     "Component",
@@ -111,6 +165,9 @@ __all__ = [
 ]
 
 Exporter = HTML
+"""Compatibility alias for the HTML exporter."""
+
+HTMLExporter = HTML
 """Compatibility alias for the HTML exporter."""
 
 HTML_CONFIG: ExporterConfig = {

--- a/draftjs_exporter/markdown/__init__.py
+++ b/draftjs_exporter/markdown/__init__.py
@@ -11,31 +11,31 @@ from draftjs_exporter.defaults import BLOCK_MAP as HTML_BLOCK_MAP
 from draftjs_exporter.defaults import STYLE_MAP as HTML_STYLE_MAP
 from draftjs_exporter.html import ExporterConfig
 from draftjs_exporter.markdown.blocks import (
-    list_wrapper,
-    make_ol,
-    make_ul,
-    ol,
-    prefixed_block,
-    ul,
+    md_list_wrapper,
+    md_make_ol,
+    md_make_ul,
+    md_ol,
+    md_prefixed_block,
+    md_ul,
 )
 from draftjs_exporter.markdown.code import (
-    code_element,
-    code_wrapper,
-    make_code_element,
-    make_code_wrapper,
+    md_code_element,
+    md_code_wrapper,
+    md_make_code_element,
+    md_make_code_wrapper,
 )
 from draftjs_exporter.markdown.entities import (
-    horizontal_rule,
-    image,
-    link,
-    make_horizontal_rule,
+    md_horizontal_rule,
+    md_image,
+    md_link,
+    md_make_horizontal_rule,
 )
 from draftjs_exporter.markdown.fallbacks import (
-    block_fallback,
-    entity_fallback,
-    style_fallback,
+    md_block_fallback,
+    md_entity_fallback,
+    md_style_fallback,
 )
-from draftjs_exporter.markdown.styles import code_span, inline_style
+from draftjs_exporter.markdown.styles import md_code_span, md_inline_style
 from draftjs_exporter.types import Component, ConfigMap
 
 
@@ -57,46 +57,46 @@ class MarkdownOptions(TypedDict, total=False):
 BLOCK_MAP: ConfigMap = {
     **HTML_BLOCK_MAP,
     **{
-        BLOCK_TYPES.UNSTYLED: prefixed_block(""),
-        BLOCK_TYPES.HEADER_ONE: prefixed_block("# "),
-        BLOCK_TYPES.HEADER_TWO: prefixed_block("## "),
-        BLOCK_TYPES.HEADER_THREE: prefixed_block("### "),
-        BLOCK_TYPES.HEADER_FOUR: prefixed_block("#### "),
-        BLOCK_TYPES.HEADER_FIVE: prefixed_block("##### "),
-        BLOCK_TYPES.HEADER_SIX: prefixed_block("###### "),
+        BLOCK_TYPES.UNSTYLED: md_prefixed_block(""),
+        BLOCK_TYPES.HEADER_ONE: md_prefixed_block("# "),
+        BLOCK_TYPES.HEADER_TWO: md_prefixed_block("## "),
+        BLOCK_TYPES.HEADER_THREE: md_prefixed_block("### "),
+        BLOCK_TYPES.HEADER_FOUR: md_prefixed_block("#### "),
+        BLOCK_TYPES.HEADER_FIVE: md_prefixed_block("##### "),
+        BLOCK_TYPES.HEADER_SIX: md_prefixed_block("###### "),
         BLOCK_TYPES.UNORDERED_LIST_ITEM: {
-            "element": ul,
-            "wrapper": list_wrapper,
+            "element": md_ul,
+            "wrapper": md_list_wrapper,
         },
         BLOCK_TYPES.ORDERED_LIST_ITEM: {
-            "element": ol,
-            "wrapper": list_wrapper,
+            "element": md_ol,
+            "wrapper": md_list_wrapper,
         },
-        BLOCK_TYPES.BLOCKQUOTE: prefixed_block("> ", block_prefix=True),
+        BLOCK_TYPES.BLOCKQUOTE: md_prefixed_block("> ", block_prefix=True),
         BLOCK_TYPES.CODE: {
-            "element": code_element,
-            "wrapper": code_wrapper,
+            "element": md_code_element,
+            "wrapper": md_code_wrapper,
         },
-        BLOCK_TYPES.FALLBACK: block_fallback,
+        BLOCK_TYPES.FALLBACK: md_block_fallback,
     },
 }
 
 STYLE_MAP: ConfigMap = dict(
     HTML_STYLE_MAP,
     **{
-        INLINE_STYLES.BOLD: inline_style("**"),
-        INLINE_STYLES.CODE: code_span,
-        INLINE_STYLES.ITALIC: inline_style("_"),
-        INLINE_STYLES.STRIKETHROUGH: inline_style("~"),
-        INLINE_STYLES.FALLBACK: style_fallback,
+        INLINE_STYLES.BOLD: md_inline_style("**"),
+        INLINE_STYLES.CODE: md_code_span,
+        INLINE_STYLES.ITALIC: md_inline_style("_"),
+        INLINE_STYLES.STRIKETHROUGH: md_inline_style("~"),
+        INLINE_STYLES.FALLBACK: md_style_fallback,
     },
 )
 
 ENTITY_DECORATORS: ConfigMap = {
-    ENTITY_TYPES.IMAGE: image,
-    ENTITY_TYPES.LINK: link,
-    ENTITY_TYPES.HORIZONTAL_RULE: horizontal_rule,
-    ENTITY_TYPES.FALLBACK: entity_fallback,
+    ENTITY_TYPES.IMAGE: md_image,
+    ENTITY_TYPES.LINK: md_link,
+    ENTITY_TYPES.HORIZONTAL_RULE: md_horizontal_rule,
+    ENTITY_TYPES.FALLBACK: md_entity_fallback,
 }
 
 ENGINE = "draftjs_exporter.engines.markdown.DOMMarkdown"
@@ -132,41 +132,41 @@ def build_markdown_config(options: MarkdownOptions | None = None) -> ExporterCon
     fence = opts.get("code_fence", "```")
 
     block_map: ConfigMap = {
-        BLOCK_TYPES.UNSTYLED: prefixed_block(""),
-        BLOCK_TYPES.HEADER_ONE: prefixed_block("# "),
-        BLOCK_TYPES.HEADER_TWO: prefixed_block("## "),
-        BLOCK_TYPES.HEADER_THREE: prefixed_block("### "),
-        BLOCK_TYPES.HEADER_FOUR: prefixed_block("#### "),
-        BLOCK_TYPES.HEADER_FIVE: prefixed_block("##### "),
-        BLOCK_TYPES.HEADER_SIX: prefixed_block("###### "),
+        BLOCK_TYPES.UNSTYLED: md_prefixed_block(""),
+        BLOCK_TYPES.HEADER_ONE: md_prefixed_block("# "),
+        BLOCK_TYPES.HEADER_TWO: md_prefixed_block("## "),
+        BLOCK_TYPES.HEADER_THREE: md_prefixed_block("### "),
+        BLOCK_TYPES.HEADER_FOUR: md_prefixed_block("#### "),
+        BLOCK_TYPES.HEADER_FIVE: md_prefixed_block("##### "),
+        BLOCK_TYPES.HEADER_SIX: md_prefixed_block("###### "),
         BLOCK_TYPES.UNORDERED_LIST_ITEM: {
-            "element": make_ul(ul_marker),
-            "wrapper": list_wrapper,
+            "element": md_make_ul(ul_marker),
+            "wrapper": md_list_wrapper,
         },
         BLOCK_TYPES.ORDERED_LIST_ITEM: {
-            "element": make_ol(ol_delimiter),
-            "wrapper": list_wrapper,
+            "element": md_make_ol(ol_delimiter),
+            "wrapper": md_list_wrapper,
         },
-        BLOCK_TYPES.BLOCKQUOTE: prefixed_block("> ", block_prefix=True),
+        BLOCK_TYPES.BLOCKQUOTE: md_prefixed_block("> ", block_prefix=True),
         BLOCK_TYPES.CODE: {
-            "element": make_code_element(),
-            "wrapper": make_code_wrapper(fence),
+            "element": md_make_code_element(),
+            "wrapper": md_make_code_wrapper(fence),
         },
         BLOCK_TYPES.ATOMIC: lambda props: props["children"],
     }
 
     style_map: ConfigMap = {
         **HTML_STYLE_MAP,
-        INLINE_STYLES.BOLD: inline_style(bold),
-        INLINE_STYLES.CODE: code_span,
-        INLINE_STYLES.ITALIC: inline_style(italic),
-        INLINE_STYLES.STRIKETHROUGH: inline_style(strikethrough),
+        INLINE_STYLES.BOLD: md_inline_style(bold),
+        INLINE_STYLES.CODE: md_code_span,
+        INLINE_STYLES.ITALIC: md_inline_style(italic),
+        INLINE_STYLES.STRIKETHROUGH: md_inline_style(strikethrough),
     }
 
     entity_decorators: ConfigMap = {
-        ENTITY_TYPES.IMAGE: image,
-        ENTITY_TYPES.LINK: link,
-        ENTITY_TYPES.HORIZONTAL_RULE: make_horizontal_rule(hr),
+        ENTITY_TYPES.IMAGE: md_image,
+        ENTITY_TYPES.LINK: md_link,
+        ENTITY_TYPES.HORIZONTAL_RULE: md_make_horizontal_rule(hr),
     }
 
     _apply_fallback(
@@ -174,21 +174,21 @@ def build_markdown_config(options: MarkdownOptions | None = None) -> ExporterCon
         BLOCK_TYPES.FALLBACK,
         "block_fallback" in opts,
         opts.get("block_fallback"),
-        block_fallback,
+        md_block_fallback,
     )
     _apply_fallback(
         style_map,
         INLINE_STYLES.FALLBACK,
         "style_fallback" in opts,
         opts.get("style_fallback"),
-        style_fallback,
+        md_style_fallback,
     )
     _apply_fallback(
         entity_decorators,
         ENTITY_TYPES.FALLBACK,
         "entity_fallback" in opts,
         opts.get("entity_fallback"),
-        entity_fallback,
+        md_entity_fallback,
     )
 
     return {

--- a/draftjs_exporter/markdown/blocks.py
+++ b/draftjs_exporter/markdown/blocks.py
@@ -1,11 +1,11 @@
 """Markdown block-level components: headings, lists, blockquotes, and plain paragraphs."""
 
-from draftjs_exporter.markdown.helpers import block, inline, mark_safe
-from draftjs_exporter.markdown.lists import list_item, make_numbered_li_prefix
+from draftjs_exporter.markdown.helpers import md_block, md_inline, md_mark_safe
+from draftjs_exporter.markdown.lists import md_list_item, md_make_numbered_li_prefix
 from draftjs_exporter.types import Component, Element, Props
 
 
-def prefixed_block(prefix: str, block_prefix: bool = False) -> Component:
+def md_prefixed_block(prefix: str, block_prefix: bool = False) -> Component:
     """Create a block component that prefixes its children with the given string.
 
     Parameters:
@@ -16,12 +16,12 @@ def prefixed_block(prefix: str, block_prefix: bool = False) -> Component:
     Returns:
         A component that renders the prefixed block.
     """
-    return lambda props: block(
-        [mark_safe(prefix, block_prefix=block_prefix), props["children"]]
+    return lambda props: md_block(
+        [md_mark_safe(prefix, block_prefix=block_prefix), props["children"]]
     )
 
 
-def make_ul(marker: str) -> Component:
+def md_make_ul(marker: str) -> Component:
     """Create an unordered list item component using the given marker.
 
     Parameters:
@@ -31,10 +31,10 @@ def make_ul(marker: str) -> Component:
         A component that renders one unordered list item.
     """
     prefix = f"{marker} "
-    return lambda props: list_item(prefix, props)
+    return lambda props: md_list_item(prefix, props)
 
 
-def make_ol(delimiter: str) -> Component:
+def md_make_ol(delimiter: str) -> Component:
     """Create an ordered list item component using the given delimiter.
 
     Parameters:
@@ -43,11 +43,11 @@ def make_ol(delimiter: str) -> Component:
     Returns:
         A component that renders one ordered list item.
     """
-    get_prefix = make_numbered_li_prefix(delimiter)
-    return lambda props: list_item(get_prefix(props), props)
+    get_prefix = md_make_numbered_li_prefix(delimiter)
+    return lambda props: md_list_item(get_prefix(props), props)
 
 
-def list_wrapper(props: Props) -> Element:
+def md_list_wrapper(props: Props) -> Element:
     """Render a list wrapper as an empty inline fragment.
 
     Markdown lists are built from individual items, so no extra wrapper
@@ -59,8 +59,8 @@ def list_wrapper(props: Props) -> Element:
     Returns:
         An empty fragment that lets list items sit next to each other.
     """
-    return inline([])
+    return md_inline([])
 
 
-ul: Component = make_ul("-")
-ol: Component = make_ol(".")
+md_ul: Component = md_make_ul("-")
+md_ol: Component = md_make_ol(".")

--- a/draftjs_exporter/markdown/code.py
+++ b/draftjs_exporter/markdown/code.py
@@ -1,11 +1,11 @@
 """Markdown code block components and fenced code builders."""
 
 from draftjs_exporter.dom import DOM
-from draftjs_exporter.markdown.helpers import mark_safe
+from draftjs_exporter.markdown.helpers import md_mark_safe
 from draftjs_exporter.types import Component, Element, Props
 
 
-def make_code_element() -> Component:
+def md_make_code_element() -> Component:
     """Create a code-block line component.
 
     Each Draft.js code block contributes one line to the shared code_block
@@ -16,12 +16,14 @@ def make_code_element() -> Component:
     """
 
     def element(props: Props) -> Element:
-        return DOM.create_element("fragment", {}, [props["children"], mark_safe("\n")])
+        return DOM.create_element(
+            "fragment", {}, [props["children"], md_mark_safe("\n")]
+        )
 
     return element
 
 
-def make_code_wrapper(fence: str) -> Component:
+def md_make_code_wrapper(fence: str) -> Component:
     """Create a code-block wrapper component using the given fence.
 
     Parameters:
@@ -35,5 +37,5 @@ def make_code_wrapper(fence: str) -> Component:
     return lambda props: DOM.create_element("code_block", {"fence": fence_char})
 
 
-code_element: Component = make_code_element()
-code_wrapper: Component = make_code_wrapper("```")
+md_code_element: Component = md_make_code_element()
+md_code_wrapper: Component = md_make_code_wrapper("```")

--- a/draftjs_exporter/markdown/entities.py
+++ b/draftjs_exporter/markdown/entities.py
@@ -1,10 +1,15 @@
 """Markdown entity decorators for images, links, and horizontal rules."""
 
-from draftjs_exporter.markdown.helpers import block, inline, link_destination, mark_safe
+from draftjs_exporter.markdown.helpers import (
+    md_block,
+    md_inline,
+    md_link_destination,
+    md_mark_safe,
+)
 from draftjs_exporter.types import Component, Element, Props
 
 
-def image(props: Props) -> Element:
+def md_image(props: Props) -> Element:
     """Render an image as a Markdown image reference.
 
     Parameters:
@@ -13,18 +18,18 @@ def image(props: Props) -> Element:
     Returns:
         A block-level image element.
     """
-    return block(
+    return md_block(
         [
-            mark_safe("!["),
+            md_mark_safe("!["),
             props.get("alt", ""),
-            mark_safe("]("),
-            link_destination(props["src"]),
-            mark_safe(")"),
+            md_mark_safe("]("),
+            md_link_destination(props["src"]),
+            md_mark_safe(")"),
         ]
     )
 
 
-def link(props: Props) -> Element:
+def md_link(props: Props) -> Element:
     """Render a link as a Markdown inline reference.
 
     Parameters:
@@ -33,18 +38,18 @@ def link(props: Props) -> Element:
     Returns:
         An inline link element.
     """
-    return inline(
+    return md_inline(
         [
-            mark_safe("["),
+            md_mark_safe("["),
             props["children"],
-            mark_safe("]("),
-            link_destination(props["url"]),
-            mark_safe(")"),
+            md_mark_safe("]("),
+            md_link_destination(props["url"]),
+            md_mark_safe(")"),
         ]
     )
 
 
-def make_horizontal_rule(marker: str) -> Component:
+def md_make_horizontal_rule(marker: str) -> Component:
     """Create a horizontal rule component using the given marker.
 
     Parameters:
@@ -53,7 +58,7 @@ def make_horizontal_rule(marker: str) -> Component:
     Returns:
         A component that renders a horizontal rule.
     """
-    return lambda props: block([mark_safe(marker)])
+    return lambda props: md_block([md_mark_safe(marker)])
 
 
-horizontal_rule: Component = make_horizontal_rule("---")
+md_horizontal_rule: Component = md_make_horizontal_rule("---")

--- a/draftjs_exporter/markdown/fallbacks.py
+++ b/draftjs_exporter/markdown/fallbacks.py
@@ -2,13 +2,13 @@
 
 import logging
 
-from draftjs_exporter.markdown.helpers import block
+from draftjs_exporter.markdown.helpers import md_block
 from draftjs_exporter.types import Element, Props
 
 logger = logging.getLogger(__name__)
 
 
-def block_fallback(props: Props) -> Element:
+def md_block_fallback(props: Props) -> Element:
     """Render an unknown block type as plain text.
 
     Parameters:
@@ -19,10 +19,10 @@ def block_fallback(props: Props) -> Element:
     """
     type_ = props["block"]["type"]
     logger.warning('Unknown block type "%s". Rendering as plain text.', type_)
-    return block([props["children"]])
+    return md_block([props["children"]])
 
 
-def entity_fallback(props: Props) -> Element:
+def md_entity_fallback(props: Props) -> Element:
     """Render an unknown entity type as plain text.
 
     Parameters:
@@ -36,7 +36,7 @@ def entity_fallback(props: Props) -> Element:
     return props["children"]
 
 
-def style_fallback(props: Props) -> Element:
+def md_style_fallback(props: Props) -> Element:
     """Render an unknown inline style as plain text.
 
     Parameters:

--- a/draftjs_exporter/markdown/helpers.py
+++ b/draftjs_exporter/markdown/helpers.py
@@ -5,7 +5,7 @@ from draftjs_exporter.markdown.escape import escape_link_destination
 from draftjs_exporter.types import Element
 
 
-def mark_safe(markup: str, block_prefix: bool = False) -> Element:
+def md_mark_safe(markup: str, block_prefix: bool = False) -> Element:
     """Create an element holding structural Markdown syntax.
 
     The Markdown engine renders ``mark_safe`` markup verbatim, without the
@@ -26,7 +26,7 @@ def mark_safe(markup: str, block_prefix: bool = False) -> Element:
     )
 
 
-def link_destination(url: str) -> Element:
+def md_link_destination(url: str) -> Element:
     """Create an element holding a link or image URL for ``](…)``.
 
     Parameters:
@@ -35,10 +35,10 @@ def link_destination(url: str) -> Element:
     Returns:
         An element rendering the escaped URL without further escaping.
     """
-    return mark_safe(escape_link_destination(url))
+    return md_mark_safe(escape_link_destination(url))
 
 
-def inline(children: list[str | Element]) -> Element:
+def md_inline(children: list[str | Element]) -> Element:
     """Create an inline fragment for inline formatting such as bold, links, and code.
 
     Parameters:
@@ -50,7 +50,7 @@ def inline(children: list[str | Element]) -> Element:
     return DOM.create_element("fragment", {}, children)
 
 
-def block(children: list[str | Element]) -> Element:
+def md_block(children: list[str | Element]) -> Element:
     """Create a block fragment followed by an empty line.
 
     Parameters:
@@ -59,4 +59,4 @@ def block(children: list[str | Element]) -> Element:
     Returns:
         A fragment containing the children and a trailing blank line.
     """
-    return DOM.create_element("fragment", {}, children + [mark_safe("\n\n")])
+    return DOM.create_element("fragment", {}, children + [md_mark_safe("\n\n")])

--- a/draftjs_exporter/markdown/lists.py
+++ b/draftjs_exporter/markdown/lists.py
@@ -3,11 +3,11 @@
 from collections.abc import Callable
 
 from draftjs_exporter.dom import DOM
-from draftjs_exporter.markdown.helpers import mark_safe
+from draftjs_exporter.markdown.helpers import md_mark_safe
 from draftjs_exporter.types import Block, Element, Props
 
 
-def get_block_index(blocks: list[Block], key: str) -> int:
+def md_get_block_index(blocks: list[Block], key: str) -> int:
     """Find the index of the block with the given key.
 
     Parameters:
@@ -21,7 +21,7 @@ def get_block_index(blocks: list[Block], key: str) -> int:
     return keys[0] if keys else -1
 
 
-def get_li_suffix(props: Props) -> str:
+def md_get_li_suffix(props: Props) -> str:
     r"""Choose a list item suffix based on the following block type.
 
     Parameters:
@@ -36,13 +36,13 @@ def get_li_suffix(props: Props) -> str:
         return "\n"
 
     blocks = props["blocks"]
-    i = get_block_index(blocks, key)
+    i = md_get_block_index(blocks, key)
     next_block_type = blocks[i + 1]["type"] if i + 1 < len(blocks) else None
 
     return "\n\n" if next_block_type != props["block"]["type"] else "\n"
 
 
-def make_numbered_li_prefix(delimiter: str) -> Callable[[Props], str]:
+def md_make_numbered_li_prefix(delimiter: str) -> Callable[[Props], str]:
     """Create a function that computes an ordered list item prefix.
 
     The returned function counts preceding list items at the same depth
@@ -86,10 +86,10 @@ def make_numbered_li_prefix(delimiter: str) -> Callable[[Props], str]:
     return get_prefix
 
 
-get_numbered_li_prefix: Callable[[Props], str] = make_numbered_li_prefix(".")
+md_get_numbered_li_prefix: Callable[[Props], str] = md_make_numbered_li_prefix(".")
 
 
-def list_item(prefix: str, props: Props) -> Element:
+def md_list_item(prefix: str, props: Props) -> Element:
     """Render a single Markdown list item with indentation and suffix.
 
     Parameters:
@@ -100,15 +100,15 @@ def list_item(prefix: str, props: Props) -> Element:
         A fragment containing the indented prefix, children, and trailing newline.
     """
     indent = "  " * props["block"]["depth"]
-    suffix = get_li_suffix(props)
+    suffix = md_get_li_suffix(props)
 
     return DOM.create_element(
         "fragment",
         {},
         [
-            mark_safe(indent, block_prefix=True),
-            mark_safe(prefix, block_prefix=True),
+            md_mark_safe(indent, block_prefix=True),
+            md_mark_safe(prefix, block_prefix=True),
             props["children"],
-            mark_safe(suffix),
+            md_mark_safe(suffix),
         ],
     )

--- a/draftjs_exporter/markdown/styles.py
+++ b/draftjs_exporter/markdown/styles.py
@@ -1,11 +1,11 @@
 """Markdown inline style components for bold, italic, code, and strikethrough."""
 
 from draftjs_exporter.dom import DOM
-from draftjs_exporter.markdown.helpers import inline, mark_safe
+from draftjs_exporter.markdown.helpers import md_inline, md_mark_safe
 from draftjs_exporter.types import Component, Element, Props
 
 
-def inline_style(mark: str) -> Component:
+def md_inline_style(mark: str) -> Component:
     """Create an inline style component that wraps text in the given mark.
 
     Parameters:
@@ -14,10 +14,12 @@ def inline_style(mark: str) -> Component:
     Returns:
         A component that renders the marked inline style.
     """
-    return lambda props: inline([mark_safe(mark), props["children"], mark_safe(mark)])
+    return lambda props: md_inline(
+        [md_mark_safe(mark), props["children"], md_mark_safe(mark)]
+    )
 
 
-def code_span(props: Props) -> Element:
+def md_code_span(props: Props) -> Element:
     """Render inline code as a code span.
 
     The engine emits the content unescaped, with delimiters sized to the

--- a/example.py
+++ b/example.py
@@ -26,9 +26,9 @@ from draftjs_exporter import (
     ExporterConfig,
     MarkdownImporter,
     Props,
+    md_link,
+    scheme_resolver,
 )
-from draftjs_exporter.markdown.entities import link as markdown_link
-from draftjs_exporter.markdown_parser import scheme_resolver
 
 
 def blockquote(props: Props) -> Element:
@@ -136,7 +136,7 @@ def linkify_markdown(props: Props) -> Element:
     if href.startswith("www"):
         link_props["url"] = "http://" + href
 
-    return markdown_link(link_props)
+    return md_link(link_props)
 
 
 def block_fallback(props: Props) -> Element:

--- a/tests/markdown/test_blocks.py
+++ b/tests/markdown/test_blocks.py
@@ -2,33 +2,33 @@ import unittest
 
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.markdown.blocks import (
-    list_wrapper,
-    make_ol,
-    make_ul,
-    ol,
-    prefixed_block,
-    ul,
+    md_list_wrapper,
+    md_make_ol,
+    md_make_ul,
+    md_ol,
+    md_prefixed_block,
+    md_ul,
 )
 
 
 class TestBlocks(unittest.TestCase):
     def test_prefixed_block(self):
         self.assertEqual(
-            DOM.render(prefixed_block("> ")({"children": "test"})), "> test\n\n"
+            DOM.render(md_prefixed_block("> ")({"children": "test"})), "> test\n\n"
         )
 
     def test_prefixed_block_uses_mark_safe(self):
-        elt = prefixed_block("# ")({"children": "x"})
+        elt = md_prefixed_block("# ")({"children": "x"})
         self.assertEqual(elt.children[0].type, "mark_safe")
 
     def test_prefixed_block_block_prefix_flag(self):
-        elt = prefixed_block("> ", block_prefix=True)({"children": "x"})
+        elt = md_prefixed_block("> ", block_prefix=True)({"children": "x"})
         self.assertEqual(elt.children[0].attr["block_prefix"], "true")
 
     def test_ul(self):
         self.assertEqual(
             DOM.render(
-                ul(
+                md_ul(
                     {
                         "block": {
                             "depth": 0,
@@ -48,7 +48,7 @@ class TestBlocks(unittest.TestCase):
         }
         self.assertEqual(
             DOM.render(
-                ol(
+                md_ol(
                     {
                         "block": b,
                         "blocks": [b],
@@ -67,7 +67,7 @@ class TestBlocks(unittest.TestCase):
         }
         self.assertEqual(
             DOM.render(
-                ol(
+                md_ol(
                     {
                         "block": b,
                         "blocks": [
@@ -84,7 +84,7 @@ class TestBlocks(unittest.TestCase):
     def test_make_ul_star(self):
         self.assertEqual(
             DOM.render(
-                make_ul("*")(
+                md_make_ul("*")(
                     {
                         "block": {"depth": 0},
                         "children": "test",
@@ -97,7 +97,7 @@ class TestBlocks(unittest.TestCase):
     def test_make_ul_plus(self):
         self.assertEqual(
             DOM.render(
-                make_ul("+")(
+                md_make_ul("+")(
                     {
                         "block": {"depth": 0},
                         "children": "test",
@@ -115,7 +115,7 @@ class TestBlocks(unittest.TestCase):
         }
         self.assertEqual(
             DOM.render(
-                make_ol(")")(
+                md_make_ol(")")(
                     {
                         "block": b,
                         "blocks": [b],
@@ -134,7 +134,7 @@ class TestBlocks(unittest.TestCase):
         }
         self.assertEqual(
             DOM.render(
-                make_ol(".")(
+                md_make_ol(".")(
                     {
                         "block": b,
                         "blocks": [
@@ -149,4 +149,4 @@ class TestBlocks(unittest.TestCase):
         )
 
     def test_list_wrapper(self):
-        self.assertEqual(DOM.render(list_wrapper({})), "")
+        self.assertEqual(DOM.render(md_list_wrapper({})), "")

--- a/tests/markdown/test_code.py
+++ b/tests/markdown/test_code.py
@@ -4,10 +4,10 @@ from draftjs_exporter.dom import DOM
 from draftjs_exporter.html import HTML
 from draftjs_exporter.markdown import CONFIG as MARKDOWN_CONFIG
 from draftjs_exporter.markdown.code import (
-    code_element,
-    code_wrapper,
-    make_code_element,
-    make_code_wrapper,
+    md_code_element,
+    md_code_wrapper,
+    md_make_code_element,
+    md_make_code_wrapper,
 )
 
 
@@ -33,7 +33,7 @@ def render_code_block(text: str) -> str:
 class TestCodeElement(unittest.TestCase):
     def test_renders_line_with_newline(self):
         self.assertEqual(
-            DOM.render(code_element({"block": {}, "children": "test"})),
+            DOM.render(md_code_element({"block": {}, "children": "test"})),
             "test\n",
         )
 
@@ -41,21 +41,21 @@ class TestCodeElement(unittest.TestCase):
 class TestMakeCodeElement(unittest.TestCase):
     def test_renders_line_with_newline(self):
         self.assertEqual(
-            DOM.render(make_code_element()({"block": {}, "children": "test"})),
+            DOM.render(md_make_code_element()({"block": {}, "children": "test"})),
             "test\n",
         )
 
 
 class TestCodeWrapper(unittest.TestCase):
     def test_renders_code_block_node(self):
-        elt = code_wrapper({"block": {}})
+        elt = md_code_wrapper({"block": {}})
         self.assertEqual(elt.type, "code_block")
         self.assertEqual(elt.attr["fence"], "`")
 
 
 class TestMakeCodeWrapper(unittest.TestCase):
     def test_tilde_fence(self):
-        elt = make_code_wrapper("~~~")({"block": {}})
+        elt = md_make_code_wrapper("~~~")({"block": {}})
         self.assertEqual(elt.attr["fence"], "~")
 
 

--- a/tests/markdown/test_entities.py
+++ b/tests/markdown/test_entities.py
@@ -2,49 +2,49 @@ import unittest
 
 from draftjs_exporter.dom import DOM
 from draftjs_exporter.markdown.entities import (
-    horizontal_rule,
-    image,
-    link,
-    make_horizontal_rule,
+    md_horizontal_rule,
+    md_image,
+    md_link,
+    md_make_horizontal_rule,
 )
 
 
 class TestEntities(unittest.TestCase):
     def test_horizontal_rule(self):
-        self.assertEqual(DOM.render(horizontal_rule({})), "---\n\n")
+        self.assertEqual(DOM.render(md_horizontal_rule({})), "---\n\n")
 
     def test_image(self):
         self.assertEqual(
-            DOM.render(image({"src": "test.png"})),
+            DOM.render(md_image({"src": "test.png"})),
             "![](test.png)\n\n",
         )
 
     def test_image_alt(self):
         self.assertEqual(
-            DOM.render(image({"src": "test.png", "alt": "test"})),
+            DOM.render(md_image({"src": "test.png", "alt": "test"})),
             "![test](test.png)\n\n",
         )
 
     def test_link(self):
         self.assertEqual(
-            DOM.render(link({"url": "http://www.example.com/", "children": "test"})),
+            DOM.render(md_link({"url": "http://www.example.com/", "children": "test"})),
             "[test](http://www.example.com/)",
         )
 
     def test_link_url_escaped(self):
         self.assertEqual(
-            DOM.render(link({"url": "https://example.com/a(b)", "children": "x"})),
+            DOM.render(md_link({"url": "https://example.com/a(b)", "children": "x"})),
             "[x](https://example.com/a\\(b\\))",
         )
 
     def test_image_src_escaped(self):
         self.assertEqual(
-            DOM.render(image({"src": "a b.png"})),
+            DOM.render(md_image({"src": "a b.png"})),
             "![](a%20b.png)\n\n",
         )
 
     def test_make_horizontal_rule_stars(self):
-        self.assertEqual(DOM.render(make_horizontal_rule("***")({})), "***\n\n")
+        self.assertEqual(DOM.render(md_make_horizontal_rule("***")({})), "***\n\n")
 
     def test_make_horizontal_rule_underscores(self):
-        self.assertEqual(DOM.render(make_horizontal_rule("___")({})), "___\n\n")
+        self.assertEqual(DOM.render(md_make_horizontal_rule("___")({})), "___\n\n")

--- a/tests/markdown/test_fallbacks.py
+++ b/tests/markdown/test_fallbacks.py
@@ -5,11 +5,11 @@ from draftjs_exporter.error import ConfigException
 from draftjs_exporter.html import HTML
 from draftjs_exporter.markdown import CONFIG, build_markdown_config
 from draftjs_exporter.markdown.fallbacks import (
-    block_fallback,
-    entity_fallback,
-    style_fallback,
+    md_block_fallback,
+    md_entity_fallback,
+    md_style_fallback,
 )
-from draftjs_exporter.markdown.helpers import block
+from draftjs_exporter.markdown.helpers import md_block
 from draftjs_exporter.types import ContentState, Element, Props
 
 LOGGER = "draftjs_exporter.markdown.fallbacks"
@@ -20,7 +20,7 @@ LOGGER = "draftjs_exporter.markdown.fallbacks"
 UNIT_CASES = [
     (
         "block",
-        block_fallback,
+        md_block_fallback,
         {"block": {"type": "custom-block"}, "children": "content"},
         "custom-block",
         "content\n\n",
@@ -28,7 +28,7 @@ UNIT_CASES = [
     ),
     (
         "entity",
-        entity_fallback,
+        md_entity_fallback,
         {"entity": {"type": "CUSTOM_ENTITY"}, "children": "link text"},
         "CUSTOM_ENTITY",
         "link text",
@@ -36,7 +36,7 @@ UNIT_CASES = [
     ),
     (
         "style",
-        style_fallback,
+        md_style_fallback,
         {"inline_style_range": {"style": "CUSTOM_STYLE"}, "children": "styled"},
         "CUSTOM_STYLE",
         "styled",
@@ -225,7 +225,7 @@ def test_custom_style_fallback():
 
 def test_custom_block_fallback():
     def custom_block(props: Props) -> Element:
-        return block(["[UNKNOWN] ", props["children"]])
+        return md_block(["[UNKNOWN] ", props["children"]])
 
     config = build_markdown_config({"block_fallback": custom_block})
     result = HTML(config).render(UNKNOWN_BLOCK_CONTENT)

--- a/tests/markdown/test_helpers.py
+++ b/tests/markdown/test_helpers.py
@@ -1,34 +1,41 @@
 import unittest
 
 from draftjs_exporter.dom import DOM
-from draftjs_exporter.markdown.helpers import block, inline, link_destination, mark_safe
+from draftjs_exporter.markdown.helpers import (
+    md_block,
+    md_inline,
+    md_link_destination,
+    md_mark_safe,
+)
 
 
 class TestHelpers(unittest.TestCase):
     def test_inline(self):
-        self.assertEqual(DOM.render(inline(["test"])), "test")
+        self.assertEqual(DOM.render(md_inline(["test"])), "test")
 
     def test_block(self):
-        self.assertEqual(DOM.render(block(["test"])), "test\n\n")
+        self.assertEqual(DOM.render(md_block(["test"])), "test\n\n")
 
 
 class TestMarkSafe(unittest.TestCase):
     def test_renders_verbatim(self):
-        self.assertEqual(DOM.render(inline([mark_safe("# "), "*x*"])), "# \\*x\\*")
+        self.assertEqual(
+            DOM.render(md_inline([md_mark_safe("# "), "*x*"])), "# \\*x\\*"
+        )
 
     def test_block_prefix_flag(self):
-        elt = mark_safe("- ", block_prefix=True)
+        elt = md_mark_safe("- ", block_prefix=True)
         self.assertEqual(elt.type, "mark_safe")
         self.assertEqual(elt.attr["block_prefix"], "true")
 
     def test_block_prefix_default_false(self):
-        elt = mark_safe("# ")
+        elt = md_mark_safe("# ")
         self.assertEqual(elt.attr["block_prefix"], "false")
 
 
 class TestLinkDestination(unittest.TestCase):
     def test_renders_escaped_url(self):
         self.assertEqual(
-            DOM.render(inline([link_destination("https://example.com/a(b)")])),
+            DOM.render(md_inline([md_link_destination("https://example.com/a(b)")])),
             "https://example.com/a\\(b\\)",
         )

--- a/tests/markdown/test_lists.py
+++ b/tests/markdown/test_lists.py
@@ -1,20 +1,20 @@
 import unittest
 
 from draftjs_exporter.dom import DOM
-from draftjs_exporter.markdown.blocks import ul
+from draftjs_exporter.markdown.blocks import md_ul
 from draftjs_exporter.markdown.lists import (
-    get_block_index,
-    get_li_suffix,
-    get_numbered_li_prefix,
-    list_item,
-    make_numbered_li_prefix,
+    md_get_block_index,
+    md_get_li_suffix,
+    md_get_numbered_li_prefix,
+    md_list_item,
+    md_make_numbered_li_prefix,
 )
 
 
 class TestGetBlockIndex(unittest.TestCase):
     def test_get_block_index(self):
         self.assertEqual(
-            get_block_index(
+            md_get_block_index(
                 [{"key": "a"}, {"key": "b"}, {"key": "c"}],
                 "b",
             ),
@@ -23,7 +23,7 @@ class TestGetBlockIndex(unittest.TestCase):
 
     def test_get_block_index_not_found(self):
         self.assertEqual(
-            get_block_index(
+            md_get_block_index(
                 [{"key": "a"}, {"key": "b"}, {"key": "c"}],
                 "h",
             ),
@@ -39,7 +39,7 @@ class TestGetLiSuffix(unittest.TestCase):
             "depth": 0,
         }
         self.assertEqual(
-            get_li_suffix(
+            md_get_li_suffix(
                 {
                     "block": b,
                     "blocks": [b, dict(b, **{"key": "b"})],
@@ -55,7 +55,7 @@ class TestGetLiSuffix(unittest.TestCase):
             "depth": 0,
         }
         self.assertEqual(
-            get_li_suffix(
+            md_get_li_suffix(
                 {
                     "block": b,
                     "blocks": [
@@ -74,7 +74,7 @@ class TestGetLiSuffix(unittest.TestCase):
             "depth": 0,
         }
         self.assertEqual(
-            get_li_suffix(
+            md_get_li_suffix(
                 {
                     "block": b,
                     "blocks": [b, dict(b)],
@@ -92,7 +92,7 @@ class TestGetNumberedLiPrefix(unittest.TestCase):
             "depth": 0,
         }
         self.assertEqual(
-            get_numbered_li_prefix(
+            md_get_numbered_li_prefix(
                 {
                     "block": b,
                     "blocks": [b, dict(b, **{"key": "b"})],
@@ -108,7 +108,7 @@ class TestGetNumberedLiPrefix(unittest.TestCase):
             "depth": 0,
         }
         self.assertEqual(
-            get_numbered_li_prefix(
+            md_get_numbered_li_prefix(
                 {
                     "block": b,
                     "blocks": [dict(b, **{"key": "b"}), b],
@@ -124,7 +124,7 @@ class TestGetNumberedLiPrefix(unittest.TestCase):
             "depth": 0,
         }
         self.assertEqual(
-            get_numbered_li_prefix(
+            md_get_numbered_li_prefix(
                 {
                     "block": b,
                     "blocks": [
@@ -146,7 +146,7 @@ class TestGetNumberedLiPrefix(unittest.TestCase):
             "depth": 0,
         }
         self.assertEqual(
-            get_numbered_li_prefix(
+            md_get_numbered_li_prefix(
                 {
                     "block": b,
                     "blocks": [
@@ -170,7 +170,7 @@ class TestGetNumberedLiPrefix(unittest.TestCase):
             "depth": 0,
         }
         self.assertEqual(
-            get_numbered_li_prefix(
+            md_get_numbered_li_prefix(
                 {
                     "block": dict(b, **{"depth": 2}),
                     "blocks": [
@@ -193,7 +193,7 @@ class TestGetNumberedLiPrefix(unittest.TestCase):
             "depth": 0,
         }
         self.assertEqual(
-            get_numbered_li_prefix(
+            md_get_numbered_li_prefix(
                 {
                     "block": b,
                     "blocks": [b],
@@ -209,7 +209,7 @@ class TestGetNumberedLiPrefix(unittest.TestCase):
             "depth": 0,
         }
         self.assertEqual(
-            get_numbered_li_prefix(
+            md_get_numbered_li_prefix(
                 {
                     "block": b,
                     "blocks": [dict(b, **{"key": "b"})],
@@ -226,7 +226,7 @@ class TestMakeNumberedLiPrefix(unittest.TestCase):
             "type": "ordered-list-item",
             "depth": 0,
         }
-        get_prefix = make_numbered_li_prefix(")")
+        get_prefix = md_make_numbered_li_prefix(")")
         self.assertEqual(
             get_prefix(
                 {
@@ -243,7 +243,7 @@ class TestMakeNumberedLiPrefix(unittest.TestCase):
             "type": "ordered-list-item",
             "depth": 0,
         }
-        get_prefix = make_numbered_li_prefix(")")
+        get_prefix = md_make_numbered_li_prefix(")")
         self.assertEqual(
             get_prefix(
                 {
@@ -260,7 +260,7 @@ class TestMakeNumberedLiPrefix(unittest.TestCase):
             "type": "ordered-list-item",
             "depth": 0,
         }
-        get_prefix = make_numbered_li_prefix(")")
+        get_prefix = md_make_numbered_li_prefix(")")
         self.assertEqual(
             get_prefix(
                 {
@@ -281,7 +281,7 @@ class TestMakeNumberedLiPrefix(unittest.TestCase):
             "type": "ordered-list-item",
             "depth": 1,
         }
-        get_prefix = make_numbered_li_prefix(")")
+        get_prefix = md_make_numbered_li_prefix(")")
         self.assertEqual(
             get_prefix(
                 {
@@ -302,7 +302,7 @@ class TestMakeNumberedLiPrefix(unittest.TestCase):
             "type": "ordered-list-item",
             "depth": 0,
         }
-        get_prefix = make_numbered_li_prefix(")")
+        get_prefix = md_make_numbered_li_prefix(")")
         self.assertEqual(
             get_prefix(
                 {
@@ -323,7 +323,7 @@ class TestMakeNumberedLiPrefix(unittest.TestCase):
             "type": "ordered-list-item",
             "depth": 0,
         }
-        get_prefix = make_numbered_li_prefix(")")
+        get_prefix = md_make_numbered_li_prefix(")")
         self.assertEqual(
             get_prefix(
                 {
@@ -339,7 +339,7 @@ class TestMakeNumberedLiPrefix(unittest.TestCase):
             "type": "ordered-list-item",
             "depth": 0,
         }
-        get_prefix = make_numbered_li_prefix(")")
+        get_prefix = md_make_numbered_li_prefix(")")
         self.assertEqual(
             get_prefix(
                 {
@@ -355,7 +355,7 @@ class TestListItem(unittest.TestCase):
     def test_list_item(self):
         self.assertEqual(
             DOM.render(
-                list_item(
+                md_list_item(
                     "- ",
                     {
                         "block": {"depth": 0},
@@ -368,7 +368,7 @@ class TestListItem(unittest.TestCase):
         )
 
     def test_list_item_marker_uses_mark_safe(self):
-        item = ul(
+        item = md_ul(
             {
                 "block": {"key": "a", "type": "unordered-list-item", "depth": 0},
                 "blocks": [],
@@ -377,13 +377,13 @@ class TestListItem(unittest.TestCase):
         )
         types = [c.type if hasattr(c, "type") else c for c in item.children]
         self.assertEqual(types, ["mark_safe", "mark_safe", "x", "mark_safe"])
-        # children ("x") sits between the prefix and suffix mark_safe nodes
+        # children ("x") sits between the prefix and suffix md_mark_safe nodes
         self.assertEqual(item.children[2], "x")
 
     def test_list_item_depth(self):
         self.assertEqual(
             DOM.render(
-                list_item(
+                md_list_item(
                     "- ",
                     {
                         "block": {"depth": 2},

--- a/tests/markdown/test_styles.py
+++ b/tests/markdown/test_styles.py
@@ -1,24 +1,26 @@
 import unittest
 
 from draftjs_exporter.dom import DOM
-from draftjs_exporter.markdown.styles import code_span, inline_style
+from draftjs_exporter.markdown.styles import md_code_span, md_inline_style
 
 
 class TestInlineStyle(unittest.TestCase):
     def test_works(self):
-        self.assertEqual(DOM.render(inline_style("*")({"children": "test"})), "*test*")
+        self.assertEqual(
+            DOM.render(md_inline_style("*")({"children": "test"})), "*test*"
+        )
 
     def test_inline_style_uses_mark_safe(self):
-        elt = inline_style("**")({"children": "x"})
+        elt = md_inline_style("**")({"children": "x"})
         self.assertEqual(elt.children[0].type, "mark_safe")
         self.assertEqual(elt.children[0].attr["markup"], "**")
 
 
 class TestCodeSpan(unittest.TestCase):
     def test_renders_code_span_node(self):
-        elt = code_span({"children": "a*b"})
+        elt = md_code_span({"children": "a*b"})
         self.assertEqual(elt.type, "code_span")
         self.assertEqual(DOM.render(elt), "`a*b`")
 
     def test_backtick_content_sized(self):
-        self.assertEqual(DOM.render(code_span({"children": "a`b"})), "``a`b``")
+        self.assertEqual(DOM.render(md_code_span({"children": "a`b"})), "``a`b``")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,12 +10,44 @@ from draftjs_exporter import (
     ContentState,
     Exporter,
     ExporterConfig,
+    HTMLExporter,
+    code_block,
+    md_block,
+    md_image,
+    md_link,
+    md_mark_safe,
+    render_children,
 )
+from draftjs_exporter.defaults import (
+    code_block as defaults_code_block,
+)
+from draftjs_exporter.defaults import (
+    render_children as defaults_render_children,
+)
+from draftjs_exporter.markdown.entities import md_image as entities_md_image
+from draftjs_exporter.markdown.entities import md_link as entities_md_link
+from draftjs_exporter.markdown.helpers import md_block as helpers_md_block
+from draftjs_exporter.markdown.helpers import md_mark_safe as helpers_md_mark_safe
 
 
 class TestTopLevelAPI(unittest.TestCase):
     def test_exporter_is_html(self):
         self.assertIs(Exporter, HTML)
+
+    def test_html_exporter_is_html(self):
+        self.assertIs(HTMLExporter, HTML)
+
+    def test_code_block_reexport(self):
+        self.assertIs(code_block, defaults_code_block)
+
+    def test_render_children_reexport(self):
+        self.assertIs(render_children, defaults_render_children)
+
+    def test_markdown_helpers_reexport(self):
+        self.assertIs(md_block, helpers_md_block)
+        self.assertIs(md_mark_safe, helpers_md_mark_safe)
+        self.assertIs(md_image, entities_md_image)
+        self.assertIs(md_link, entities_md_link)
 
     def test_all_members_importable(self):
         for name in draftjs_exporter.__all__:


### PR DESCRIPTION
## Summary
- Rename Markdown component helpers to an `md_` prefix (`md_link`, `md_image`, `md_mark_safe`, …) so they can live alongside HTML helpers without name clashes.
- Re-export those helpers from the package root for simpler consumer imports.
- Also re-export HTML defaults `code_block` / `render_children`, and add the `HTMLExporter` alias for `HTML`.
- Update docs, changelog, example, and tests for the new public API.

## Test plan
- [x] `just test tests/test_init.py tests/markdown/`
- [x] `just lint`
- [ ] CI green on the PR


Made with [Cursor](https://cursor.com)