### PR TITLE
Run ruff via prek local system hooks, on Markdown too

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -33,12 +33,21 @@ hooks = [
 ]
 
 [[repos]]
-repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = "v0.15.9"
-hooks = [{ id = "ruff-check", args = ["--fix"] }, { id = "ruff-format" }]
-
-[[repos]]
 repo = "local"
+
+[[repos.hooks]]
+id = "ruff-check"
+name = "ruff-check"
+entry = "uv run ruff check --fix"
+language = "system"
+types = ["python"]
+
+[[repos.hooks]]
+id = "ruff-format"
+name = "ruff-format"
+entry = "uv run ruff format"
+language = "system"
+types_or = ["python", "markdown"]
 
 [[repos.hooks]]
 id = "prettier"


### PR DESCRIPTION
## Summary
- Replace the pinned `astral-sh/ruff-pre-commit` mirror repo (rev `v0.15.9`) with local `system`-language hooks that call `uv run ruff check --fix` and `uv run ruff format`, so prek always uses the same ruff version as `uv.lock`/CI instead of a separately-pinned mirror revision.
- `ruff-format` now runs against Markdown files as well as Python (`types_or = ["python", "markdown"]`), so drift in fenced Python code blocks in docs (like the one just fixed on #154) is caught locally instead of only in CI.

## Test plan
- [x] `prek run --all-files` passes cleanly
- [x] Verified `ruff-format` catches and fixes reformatted Markdown code blocks (tested by intentionally breaking quote style in a doc, confirming the hook flags/fixes it, then reverting)
- [x] Verified `ruff-check` still only targets Python files (ruff doesn't lint embedded Markdown code)